### PR TITLE
Two issues: old associations missing in test, crash when old associations present in console.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     minitest (5.8.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    paper_trail (4.0.0.rc2)
+    paper_trail (4.0.0)
       activerecord (>= 3.0, < 6.0)
       activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
@@ -123,6 +123,3 @@ DEPENDENCIES
   rails (= 4.2.3)
   rspec-rails
   sqlite3
-
-BUNDLED WITH
-   1.10.5

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,4 +2,22 @@ class Document < ActiveRecord::Base
   has_many :sections
   has_many :paragraphs, through: :sections
   has_paper_trail
+
+  def self.create_sample_document
+    d = Document.create!(title: "d v1")
+    s1 = Section.create!(document: d, title: "s1 v1")
+    s2 = Section.create!(document: d, title: "s2 v1")
+    p1a = Paragraph.create!(section: s1, title: "p1a v1")
+    p1b = Paragraph.create!(section: s1, title: "p1b v1")
+    p2a = Paragraph.create!(section: s2, title: "p2a v1")
+    p2b = Paragraph.create!(section: s2, title: "p2b v1")
+    puts 'Updating some paragraph'
+    p1a.update_attributes(title: 'p1a v2')
+    puts 'Updating a section name'
+    s1.update_attributes(title: 's1 v2')
+    puts 'Updating document itself'
+    d.update_attributes(title: 'd v2')
+    p1a.update_attributes(title: 'p1a v3')
+    d
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -17,6 +17,7 @@ class Document < ActiveRecord::Base
     s1.update_attributes(title: 's1 v2')
     puts 'Updating document itself'
     d.update_attributes(title: 'd v2')
+    s1.update_attributes(title: 's1 v3')
     p1a.update_attributes(title: 'p1a v3')
     d
   end

--- a/spec/model/document_spec.rb
+++ b/spec/model/document_spec.rb
@@ -5,16 +5,18 @@ RSpec.describe Document do
   it "works" do
     # document = FactoryGirl.create(:document_with_sections_and_paragraphs)
     d = Document.create_sample_document
-    puts 'Current version of document'
+
+    puts 'Current version of document, has two sections'
     expect(d.title).to eq("d v2")
     expect(d.sections.length).to eq(2)
-    expect(d.paragraphs.length).to eq(4)
+
+    puts 'Update the document'
+    d.update_attributes(title: 'd v3')
 
     puts 'Previous version of document'
     d_v2 = d.versions.last.reify(:has_many => true)
-    expect(d_v2.title).to eq("d v1")
+    expect(d_v2.title).to eq("d v2")
     # The below fails. Associations are missing
     expect(d_v2.sections.length).to eq(2)  #however, code returns 0
-    expect(d_v2.paragraphs.length).to eq(4) #however, code returns 0
   end
 end

--- a/spec/model/document_spec.rb
+++ b/spec/model/document_spec.rb
@@ -4,24 +4,17 @@ require "pp"
 RSpec.describe Document do
   it "works" do
     # document = FactoryGirl.create(:document_with_sections_and_paragraphs)
-    d = Document.create!(title: "d v1")
-    s1 = Section.create!(document: d, title: "s1 v1")
-    s2 = Section.create!(document: d, title: "s2 v1")
-    p1a = Paragraph.create!(section: s1, title: "p1a v1")
-    p1b = Paragraph.create!(section: s1, title: "p1b v1")
-    p2a = Paragraph.create!(section: s2, title: "p2a v1")
-    p2b = Paragraph.create!(section: s2, title: "p2b v1")
-    puts 'Updating some paragraph'
-    p1a.update_attributes(title: 'p1a v2')
-    puts 'Updating a section name'
-    s1.update_attributes(title: 's1 v2')
-    puts 'Updating document itself'
-    d.update_attributes(title: 'd v2')
-    p1a.update_attributes(title: 'p1a v3')
+    d = Document.create_sample_document
+    puts 'Current version of document'
+    expect(d.title).to eq("d v2")
+    expect(d.sections.length).to eq(2)
+    expect(d.paragraphs.length).to eq(4)
+
     puts 'Previous version of document'
     d_v2 = d.versions.last.reify(:has_many => true)
     expect(d_v2.title).to eq("d v1")
-    expect(d.sections.length).to eq(2)
-    expect(d.paragraphs.length).to eq(4)
+    # The below fails. Associations are missing
+    expect(d_v2.sections.length).to eq(2)  #however, code returns 0
+    expect(d_v2.paragraphs.length).to eq(4) #however, code returns 0
   end
 end


### PR DESCRIPTION
For me, there are two distinct issues. In test mode, behaviour is different than from the console. In test, the old version no longer has the associations - test app shows this. But the crash, I only get in console. I don't know how to reproduce in test mode (I think it would crash there too, if the associations were not lost). Here is the code reproducing the issue in console:

From the console:  (bundle exec bin/rails console)
    ActiveRecord::Migrator.migrate "db/migrate"
    d = Document.create_sample_document
    d_v2 = d.versions.last.reify(:has_many => true)
last line fails with 

NoMethodError: undefined method `section_id' for #<Section:0x00000001566318>
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/activemodel-4.2.3/lib/active_model/attribute_methods.rb:433:in`method_missing'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:394:in `block (2 levels) in reify_has_many_through'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/activerecord-4.2.3/lib/active_record/relation/delegation.rb:46:in`map'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/activerecord-4.2.3/lib/active_record/relation/delegation.rb:46:in `map'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:394:in`block in reify_has_many_through'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:391:in `each'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:391:in`reify_has_many_through'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:347:in `reify_has_manys'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:232:in`block in reify'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:303:in `call'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:303:in`without_identity_map'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/paper_trail-4.0.0/lib/paper_trail/version_concern.rb:168:in `reify'
    from (irb):3
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/railties-4.2.3/lib/rails/commands/console.rb:110:in`start'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/railties-4.2.3/lib/rails/commands/console.rb:9:in `start'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:68:in`console'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
    from /home/andre/.rvm/gems/ruby-2.1.2/gems/railties-4.2.3/lib/rails/commands.rb:17:in`<top (required)>'
